### PR TITLE
Add go workspace files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ __debug_bin*
 # Local env
 .env
 .env.local
+
+# Go workspace
+go.work
+go.work.sum


### PR DESCRIPTION
Adds go.work and go.work.sum to gitignore for Go workspace support.